### PR TITLE
Add cache to Atramhasisprovider methods.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.22.0
 #skosprovider==0.7.0
+dogpile.cache==0.9.0
 -e git+https://github.com/koenedaele/skosprovider.git@DEV_0.7.0#egg=skosprovider

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,4 @@ setup(
     author_email='ict@onroerenderfgoed.be',
     url='https://github.com/OnroerendErfgoed/skosprovider_atramhasis',
     keywords='atramhasis skos skosprovider thesauri vocabularies',
-    test_suite='nose.collector'
 )

--- a/skosprovider_atramhasis/cache_utils.py
+++ b/skosprovider_atramhasis/cache_utils.py
@@ -1,0 +1,59 @@
+import functools
+import json
+
+from dogpile.util import compat
+
+
+def _atramhasis_key_generator(namespace, fn, to_str=compat.string_type):
+    """
+    This is mostly a copy of dogpile.cache.util.function_key_generator.
+
+    The main difference is that it adds the provider's `base_url` and
+    `scheme_id` as part of the cache key, so that different providers
+    don't use each other's caches. As well as we try and handle kwargs.
+    """
+    if namespace is None:
+        namespace = '%s:%s' % (fn.__module__, fn.__name__)
+    else:
+        namespace = '%s:%s|%s' % (fn.__module__, fn.__name__, namespace)
+
+    def generate_key(*args, **kwargs):
+        provider = args[0]
+        args = ([provider.base_url, provider.scheme_id]
+                + list(args[1:]) + [json.dumps(kwargs, sort_keys=True)])
+        return namespace + "|" + " ".join(map(to_str, args))
+    return generate_key
+
+
+def _dont_cache_false(value):
+    """
+    Returns True when the value should be cached.
+
+    Because the provider can return False in error cases, we must prevent False
+    from being cached by dogpile.
+    """
+    return value is not False
+
+
+def _cache_on_arguments(cache_name, expiration_time=None):
+    """
+    Cache a method call in a cache region found in `self.caches[cache_name]`.
+
+    The first parameter of the cached method is assumed to be the "self".
+
+    In this `self` object the attribute "caches" will be taken. This is
+    assumed to be a dict. This dict must have the `cache_name` key with
+    a dogpile region as value.
+    """
+    def decorator(fn):
+        key_generator = _atramhasis_key_generator(None, fn)
+
+        @functools.wraps(fn)
+        def wrapped(*args, **kwargs):
+            self = args[0]
+            key = key_generator(*args, **kwargs)
+            return self.caches[cache_name].get_or_create(
+                key, fn, expiration_time, _dont_cache_false, (args, kwargs)
+            )
+        return wrapped
+    return decorator

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
+import functools
 import unittest
+from contextlib import contextmanager
 
 from skosprovider.exceptions import ProviderUnavailableException
 from skosprovider.skos import (
@@ -15,6 +16,7 @@ import responses
 from skosprovider_atramhasis.providers import (
     AtramhasisProvider
 )
+from skosprovider_atramhasis.providers import atramhasis_region
 from tests import init_responses
 
 import pytest
@@ -518,3 +520,124 @@ class AtramhasisProviderMockTests(unittest.TestCase):
         response = provider._request("http://localhost/no_encoding")
         assert response.encoding == "utf-8"
 
+
+
+@contextmanager
+def real_cache():
+    """Enables the cache for the duration of the context.
+
+    Caching is usually not desirable during testing, but this will turn it on
+    temporarily.
+
+    Usage:
+
+       with real_cache():
+           code
+    """
+    try:
+        atramhasis_region.configure('dogpile.cache.memory',
+                                    replace_existing_backend=True)
+        yield
+    finally:
+        atramhasis_region.configure('dogpile.cache.null',
+                                    replace_existing_backend=True)
+
+
+class CacheTests(unittest.TestCase):
+
+    def test_cached_unique_per_provider_scheme(self):
+        url = 'http://127.0.0.1/thesaurus'
+        schemes = ('GEBEURTENISTYPES', 'WAARDETYPES')
+        with responses.RequestsMock() as rsps:
+            for scheme in schemes:
+                rsps.add(
+                    method='GET',
+                    url=url + '/conceptschemes/' + scheme + '/c/1',
+                    json={
+                        "label": scheme.title() + " type 1",
+                        "id": 1,
+                        "type": "concept"
+                    })
+                rsps.add(
+                    method='GET',
+                    url=url + '/conceptschemes/' + scheme + '/c/2',
+                    json={
+                        "label": scheme.title() + " type 2",
+                        "id": 2,
+                        "type": "concept"
+                    })
+            # Create 2 different providers
+            provider1, provider2 = (
+                AtramhasisProvider({'id': scheme.lower(), 'default_language': 'nl'},
+                                   base_url=url,
+                                   scheme_id=scheme)
+                for scheme in schemes
+            )
+
+            with real_cache():
+                # Both request the same ID.
+                thesaurus_calls = len(rsps.calls)
+                result_1 = provider1.get_by_id('1')
+                self.assertEqual(thesaurus_calls + 1, len(rsps.calls))
+                result_2 = provider2.get_by_id('1')
+                self.assertEqual(thesaurus_calls + 2, len(rsps.calls))
+                # Results must be different
+                self.assertNotEqual(result_1, result_2)
+
+                # Do 2 more identical calls, they should return from cache.
+                provider1.get_by_id('1')
+                provider2.get_by_id('1')
+                self.assertEqual(thesaurus_calls + 2, len(rsps.calls))
+
+                # Do 2 other calls, they should not return from cache.
+                provider1.get_by_id('2')
+                provider2.get_by_id('2')
+                self.assertEqual(thesaurus_calls + 4, len(rsps.calls))
+
+    def test_cache_unique_per_url(self):
+        urls = ('http://127.0.0.1/thesaurus1', 'http://127.0.0.1/thesaurus2')
+        scheme = 'GEBEURTENISTYPES'
+        with responses.RequestsMock() as rsps:
+            for url in urls:
+                rsps.add(
+                    method='GET',
+                    url=url + '/conceptschemes/' + scheme + '/c/1',
+                    json={
+                        "label": scheme.title() + " type 1",
+                        "id": 1,
+                        "type": "concept"
+                    })
+                rsps.add(
+                    method='GET',
+                    url=url + '/conceptschemes/' + scheme + '/c/2',
+                    json={
+                        "label": scheme.title() + " type 2",
+                        "id": 2,
+                        "type": "concept"
+                    })
+            # Create 2 different providers
+            provider1, provider2 = (
+                AtramhasisProvider({'id': scheme.lower(), 'default_language': 'nl'},
+                                   base_url=url,
+                                   scheme_id=scheme)
+                for url in urls
+            )
+            with real_cache():
+                # Both request the same ID.
+                thesaurus_calls = len(rsps.calls)
+                result_1 = provider1.get_by_id('1')
+                self.assertEqual(thesaurus_calls + 1, len(rsps.calls))
+                result_2 = provider2.get_by_id('1')
+                self.assertEqual(thesaurus_calls + 2, len(rsps.calls))
+                # Results must be different
+                self.assertNotEqual(result_1, result_2)
+
+                # Do 2 more identical calls, they should return from cache.
+                provider1.get_by_id('1')
+                provider2.get_by_id('1')
+                self.assertEqual(thesaurus_calls + 2, len(rsps.calls))
+
+                # Do 2 other calls, they should not return from cache.
+                provider1.get_by_id('2')
+                provider2.get_by_id('2')
+                self.assertEqual(thesaurus_calls + 4, len(rsps.calls))


### PR DESCRIPTION
Enkele opmerkingen:

De cache config is niet per instantie, maar het lijkt alsof dat zo is.
```py
provider1 = AtramhasisProvider(..., cache_config={'backend': 'a'})
provider2 = AtramhasisProvider(..., cache_config={'backend': 'b'})
```
resultaat is dat beide providers backend `a` zullen hebben. Dit is in lijn met oeauth en andere, maar het ziet er wel vreemd uit.

----

Verschillende provider objecten met dezelfde url en conceptscheme delen hun cache.
```py
provider1 = AtramhasisProvider(same)
provider2 = AtramhasisProvider(same)
# provider 1 and 2 will use the same cache.
```
Dit kan voor en nadelen hebben.

----
Staat los van deze PR, maar  AtramhasisProvider.__init__ doet geen super meer. Ik weet niet of dit intended is?