### PR TITLE
Feature/95 upgrade dogpilecache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.23.0
 skosprovider==0.7.0
 # -e git+https://github.com/koenedaele/skosprovider.git@DEV_0.7.0#egg=skosprovider
-dogpile.cache==0.9.0
+dogpile.cache==1.1.2

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ packages = [
 requires = [
     'skosprovider>=0.7.0',
     'requests',
-    'dogpile.cache>=0.9.0',
+    'dogpile.cache>=1.1.0',
 ]
 setup(
     name='skosprovider_atramhasis',

--- a/skosprovider_atramhasis/cache_utils.py
+++ b/skosprovider_atramhasis/cache_utils.py
@@ -5,10 +5,8 @@ Utility functions for chaching in :mod:`skosprovider_atramhasis`.
 import functools
 import json
 
-from dogpile.util import compat
 
-
-def _atramhasis_key_generator(namespace, fn, to_str=compat.string_type):
+def _atramhasis_key_generator(namespace, fn, to_str=str):
     """
     This is mostly a copy of dogpile.cache.util.function_key_generator.
 


### PR DESCRIPTION
Dit gaat verder op de python2 drop PR omdat dogpile.cache zelf sinds 1.0.0 geen python2 meer support.