### PR TITLE
Don't require fetching conceptscheme for registering.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.23.0
-skosprovider==0.7.0
+skosprovider==0.7.1
 # -e git+https://github.com/koenedaele/skosprovider.git@DEV_0.7.0#egg=skosprovider
 dogpile.cache==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ packages = [
 ]
 
 requires = [
-    'skosprovider>=0.7.0',
+    'skosprovider>=0.7.1',
     'requests',
     'dogpile.cache>=0.9.0',
 ]

--- a/skosprovider_atramhasis/providers.py
+++ b/skosprovider_atramhasis/providers.py
@@ -50,6 +50,8 @@ class AtramhasisProvider(VocabularyProvider):
         """
         if 'subject' not in metadata:
             metadata['subject'] = []
+        if 'uri' not in metadata:
+            metadata['uri'] = f'{self.base_url}/conceptschemes/{self.scheme_id}'
         self.metadata = metadata
         self.allowed_instance_scopes = kwargs.get(
             'allowed_instance_scopes',


### PR DESCRIPTION
Ik denk dat het hierop neerkomt.

Bij het registreren moeten we vermijden dat hij `.conceptscheme` gaat doen, want da's een http call
https://github.com/koenedaele/skosprovider/blob/bad46ad642f17be38e59f7e7a5beefd5a21c29de/skosprovider/registry.py#L108-L112

Wat er dus op neerkomt dat er in de metadata een `uri` moet zitten.
https://github.com/koenedaele/skosprovider/blob/bad46ad642f17be38e59f7e7a5beefd5a21c29de/skosprovider/providers.py#L160-L168

Als ik een voorbeeld conceptscheme ophaal: https://thesaurus.onroerenderfgoed.be/conceptschemes/BEROEPEN_EN_OPLEIDINGEN
geeft dit
<img src="https://user-images.githubusercontent.com/4599667/106911191-3616ee00-6702-11eb-96ab-03deb1c6a121.png" width="400px" />
En die `uri` linkt terug door naar https://thesaurus.onroerenderfgoed.be/conceptschemes/BEROEPEN_EN_OPLEIDINGEN

Dus ik vul de conceptscheme url maar in als uri... De echte uri (met `https://id.erfgoed.net`) genereren zie ik niet echt hoe we dat zouden moeten doen. Projecten kunnen ook altijd `uri` zelf in de metadata invullen om te overriden, of moeten we dit verplichten dat de uri wordt meegegeven ipv zelf te proberen genereren? (@koenedaele )

