### PR TITLE
Ensure the custom requests.Session provided in tests is properly closed

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -174,7 +174,11 @@ class AtramhasisProviderMockTests(unittest.TestCase):
         import requests
         sess = requests.Session()
         provider = AtramhasisProvider({'id': 'Atramhasis'}, base_url='http://localhost', scheme_id='STYLES', session=sess)
-        assert sess == provider.session
+        try:
+            assert sess == provider.session
+        finally:
+            sess.close()
+
 
     @responses.activate
     def test_conceptscheme(self):


### PR DESCRIPTION
This PR ensures that a custom requests.Session provided in tests is explicitly closed after use.

While the session was previously left open, explicitly closing it makes resource management clearer and avoids potential connection leaks during test execution.

The issue was identified during an ongoing research project.