### PR TITLE
Deprecate skosprovider_atramhasis (#146)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,28 @@
 skosprovider_atramhasis
 =======================
 
+⚠️ This package is deprecated. Use
+`skosprovider <https://github.com/OnroerendErfgoed/skosprovider/>`_ instead.
+
+Starting from `skosprovider` 2.0.0 the functionality of this package has been
+merged into the main `skosprovider <https://github.com/OnroerendErfgoed/skosprovider/>`_
+repository. This package will remain usable with ``skosprovider < 2.0.0``, but is
+no longer actively maintained. It is recommended to upgrade to
+``skosprovider >= 2.0.0`` and use ``skosprovider_atramhasis`` from there.
+
+Migrating to skosprovider 2.0.0
+-------------------------------
+
+1. Uninstall ``skosprovider_atramhasis`` and install ``skosprovider >= 2.0.0``::
+
+       pip uninstall skosprovider_atramhasis
+       pip install "skosprovider>=2.0.0"
+
+2. Replace any ``skosprovider_atramhasis`` imports with their equivalent under
+   ``skosprovider`` (see the `skosprovider
+   <https://github.com/OnroerendErfgoed/skosprovider/>`_ documentation for the
+   full mapping).
+
 A `Skosprovider <http://skosprovider.readthedocs.org>`_ that can talk to an
 `Atramhasis <http://atramhasis.readthedocs.org>`_ instance.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,15 @@
 Skosprovider_atramhasis
 =======================
 
+.. warning::
+
+   This package is deprecated. Starting from ``skosprovider`` 2.0.0 the
+   functionality of this package has been merged into the main
+   `skosprovider <https://github.com/OnroerendErfgoed/skosprovider/>`_
+   repository. This package will remain usable with ``skosprovider < 2.0.0``,
+   but is no longer actively maintained. It is recommended to upgrade to
+   ``skosprovider >= 2.0.0`` and use ``skosprovider_atramhasis`` from there.
+
 .. toctree::
    :maxdepth: 2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "Skosprovider implementation of Atramhasis Vocabularies"
 requires-python = ">=3.11,<3.13"
 keywords = ["rdf", "skos", "skosprovider", "vocabularies", "thesauri"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 7 - Inactive",
     "Programming Language :: Python",
     "Framework :: Pyramid",
     "Topic :: Internet :: WWW/HTTP",
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "requests>=2.32.3",
-    "skosprovider>=1.2.0",
+    "skosprovider>=1.2.0,<2.0.0",
     "dogpile.cache>=1.1.4",
 ]
 

--- a/skosprovider_atramhasis/__init__.py
+++ b/skosprovider_atramhasis/__init__.py
@@ -1,0 +1,7 @@
+import warnings
+
+warnings.warn(
+    'skosprovider_atramhasis is deprecated. Please use `skosprovider>=2.0.0` instead.',
+    DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
## Summary
- Add deprecation banner to README and `.. warning::` block in docs
- Emit `DeprecationWarning` on package import
- Cap `skosprovider` dependency to `<2.0.0` and mark package as `Development Status :: 7 - Inactive`
- Add short migration section pointing to the merged `skosprovider` repo

Refs #146. Version bump and `CHANGES.rst` entry will be added by admin with the final release.
